### PR TITLE
Declaration of global $DIC inserted

### DIFF
--- a/classes/container/PegasusHelperContainer.php
+++ b/classes/container/PegasusHelperContainer.php
@@ -33,6 +33,7 @@ final class PegasusHelperContainer
      */
     public static function bootstrap()
     {
+        global $DIC;
         static::$container = $GLOBALS['DIC'];
 
         static::$container->register(new AuthenticationProvider());


### PR DESCRIPTION
Declaration of global $DIC was missing in function bootstrap().

composer.phar reports:
PHP Notice:  Undefined index: DIC in /path/to/ilias/Customizing/global/plugins/Services/UIComponent/UserInterfaceHook/PegasusHelper/classes/container/PegasusHelperContainer.php on line 36